### PR TITLE
test: add Playwright E2E tests (9 tests)

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Landing Page", () => {
+  test("renders hero section", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Getting Roasted");
+    await expect(page.getByText("AI-Powered Resume Critique", { exact: true })).toBeVisible();
+  });
+
+  test("shows upload and paste tabs", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "Upload PDF" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Paste Text" })).toBeVisible();
+  });
+
+  test("roast button is disabled when no input", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "Roast My Resume" })).toBeDisabled();
+  });
+
+  test("roast button enables after pasting text", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Paste Text" }).click();
+    await page.getByPlaceholder("Paste your resume text here").fill("Test resume content for validation.");
+    await expect(page.getByRole("button", { name: "Roast My Resume" })).toBeEnabled();
+  });
+
+  test("shows honest social proof (no fake numbers)", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("Free instant feedback")).toBeVisible();
+    await expect(page.getByText("No signup required")).toBeVisible();
+  });
+});

--- a/e2e/roast-flow.spec.ts
+++ b/e2e/roast-flow.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+const RESUME_TEXT =
+  "John Smith - Software Developer. 5 years experience. " +
+  "TechCorp (2020-2025): Worked on various projects, fixed bugs. " +
+  "Skills: JavaScript, Python, React, Node.js, AWS. " +
+  "Education: BS Computer Science 2018.";
+
+test.describe("Roast Flow", () => {
+  // Single AI call test — covers full flow, share, payments, and reset
+  test("full roast lifecycle", async ({ page }) => {
+    test.slow(); // AI call can take 30-60s
+
+    // Submit
+    await page.goto("/");
+    await page.getByRole("button", { name: "Paste Text" }).click();
+    await page.getByPlaceholder("Paste your resume text here").fill(RESUME_TEXT);
+    await page.getByRole("button", { name: "Roast My Resume" }).click();
+
+    // Loading state
+    await expect(
+      page.locator("text=/Firing up|Judging|Counting|Checking|Evaluating|Consulting|Measuring|Scanning/")
+    ).toBeVisible({ timeout: 5000 });
+
+    // Wait for results
+    await expect(page.getByText("Your Resume Score")).toBeVisible({ timeout: 90000 });
+
+    // Verify result sections
+    await expect(page.getByText("Top Issues")).toBeVisible();
+    await expect(page.getByText("ATS Compatibility")).toBeVisible();
+    await expect(page.getByText("First Impression")).toBeVisible();
+    await expect(page.getByText("Want the Full Roast?")).toBeVisible();
+
+    // Share button → toast (clipboard may fail in headless/HTTP, so accept either toast)
+    await page.getByRole("button", { name: "Share Results" }).click();
+    await expect(page.getByText(/Link copied!|Failed to copy link/)).toBeVisible({ timeout: 5000 });
+
+    // Payment button → coming soon toast
+    await page.getByRole("button", { name: /Full Roast.*\$9\.99/ }).click();
+    await expect(page.getByText("Coming soon!")).toBeVisible({ timeout: 3000 });
+
+    // Reset
+    await page.getByRole("button", { name: "Roast Another", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Upload PDF" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Roast My Resume" })).toBeDisabled();
+  });
+});

--- a/e2e/share-results.spec.ts
+++ b/e2e/share-results.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import { compressToEncodedURIComponent } from "lz-string";
+
+function buildEncodedShareParam() {
+  // Minimal SharePayload (v:1) to render a page without hitting the AI endpoint
+  const payload = {
+    v: 1,
+    s: 42,
+    sm: "Test roast summary for shared page.",
+    ti: ["Issue 1", "Issue 2", "Issue 3"],
+    as: 55,
+    ai: ["ATS issue"],
+    sc: [
+      {
+        n: "First Impression",
+        s: 40,
+        r: "Ouch.",
+        t: ["Tip 1", "Tip 2"],
+      },
+    ],
+    rb: [],
+  };
+  return compressToEncodedURIComponent(JSON.stringify(payload));
+}
+
+test.describe("Share Results (/roast)", () => {
+  test("shared URL renders results page (no AI call)", async ({ page }) => {
+    const r = buildEncodedShareParam();
+    await page.goto(`/roast?r=${r}`);
+
+    await expect(page.getByText("Your Resume Score")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Top Issues")).toBeVisible();
+    await expect(page.getByText("ATS Compatibility")).toBeVisible();
+  });
+
+  test("invalid share URL shows error page", async ({ page }) => {
+    await page.goto("/roast?r=invalid-data");
+    await expect(page.getByText(/invalid|expired/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("link", { name: /roast/i })).toBeVisible();
+  });
+
+  test("missing r param shows error page", async ({ page }) => {
+    await page.goto("/roast");
+    await expect(page.getByText(/no results/i)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -2832,6 +2833,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -11092,6 +11109,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",
@@ -25,6 +26,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  retries: 1,
+  use: {
+    baseURL: "http://localhost:3000",
+    headless: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Adds basic Playwright E2E test coverage:

**Landing Page (5 tests):**
- Hero section renders
- Upload/Paste tabs visible
- Roast button disabled without input
- Roast button enables with text
- Honest social proof (no fake numbers)

**Roast Flow (1 test, `test.slow()`):**
- Full lifecycle: paste text → loading → results → share toast → payment toast → reset

**Share Results (3 tests, no AI dependency):**
- Shared URL renders results (precomputed lz-string payload)
- Invalid share URL shows error
- Missing r param shows error

Run: `npm run e2e` (requires Docker container on port 3000)
